### PR TITLE
Fixed Support for paged files outside of root of file system.

### DIFF
--- a/src/paged.plugin.coffee
+++ b/src/paged.plugin.coffee
@@ -17,16 +17,15 @@ module.exports = (BasePlugin) ->
 
 				outExtension = firstPage.get('outExtension')
 				baseName = firstPage.get('basename')
+				firstPageUrl = firstPage.get('firstPageUrl')
 
 				if pageNumber == 0
-					return firstPage.get('url')
-
-				firstPageUrl = firstPage.get('firstPageUrl')
+					return firstPageUrl
 
 				if (firstPageUrl=='/')
 					newUrl = '/index.' + pageNumber + '.html'
 				else
-					newUrl = firstPageUrl.replace(/\.html/,'.'+pageNumber+'.html')
+					newUrl = firstPageUrl + '/index.' + pageNumber + '.html'
 
 				cleanUrls = docpad.getPlugin('cleanurls')
 				if (cleanUrls)


### PR DESCRIPTION
I made these changes to restore support for paged files that lived in a sub-directory. Previously if the blog was in /blog/ all the URLs generated by `getPagedUrl` would point to /blog/. 

These changes work in docpad@6.30.x. 
