### PR TITLE
Rename getPageUrl() to getPagedUrl()

### DIFF
--- a/src/paged.plugin.coffee
+++ b/src/paged.plugin.coffee
@@ -33,7 +33,7 @@ module.exports = (BasePlugin) ->
 			{templateData} = opts
 
 			# Get the url of the desired page
-			templateData.getPageUrl = (pageNumber, document) ->
+			templateData.getPagedUrl = (pageNumber, document) ->
 				# Prepare
 				document ?= @getDocument()
 				page = document.get('page')
@@ -76,7 +76,7 @@ module.exports = (BasePlugin) ->
 
 				# Check
 				if page.number < page.count-1
-					result = @getPageUrl(page.number+1, document)
+					result = @getPagedUrl(page.number+1, document)
 
 				# Default
 				return result
@@ -102,7 +102,7 @@ module.exports = (BasePlugin) ->
 
 				# Check
 				if page.number > 0
-					result = @getPageUrl(page.number-1, document)
+					result = @getPagedUrl(page.number-1, document)
 
 				# Return
 				return result


### PR DESCRIPTION
The docs state this template helper should be named getPagedUrl(). Further, getPageUrl() conflicts with a template function of the same name in docpad-plugin-services, which makes using both plugins unpredictable.
