### PR TITLE
Add cleanurl, startingPageNumber, and pagePathPrefix options

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,45 @@ pageSize: 1
 </div>
 ```
 
+### Plugin Configuration Options
+
+#### cleanurl
+
+Set this to _true_ and the plugin will generate clean urls.  This defaults to false.
+
+For normal documents (e.g. archives.html), the generated url pattern will be:
+
+* /archives/
+* /archives/1/
+* /archives/2/
+* /archives/3/
+* etc...
+
+For a document named index.html, the generated url pattern will be:
+
+* /
+* /1/
+* /2/
+* /3/
+* etc...
+
+#### startingPageNumber
+
+This option controls what the page number will be for the first _extra_ page.  It defaults to 1 (e.g. index.html, index.1.html, index.2.html, etc...)  If startingPageNumber = 2, you'd get index.html, index.2.html, index.3.html, etc...
+
+### Other Document-Specific Meta Data Options
+
+#### pagePathPrefix
+
+Set this meta data property to a string to be used as the prefix for any _extra_ files created.  This is useful for a main blog index in combination with the cleanurl and startingPageNumber options.  
+
+For example, for a file named index.html, with pagePathPrefix = 'page', startingPageNumber = 2, and clean urls enabled, you'd get this sequence:
+
+* /
+* /page/2/
+* /page/3/
+* /page/4/
+* etc...
 
 ## History
 [You can discover the history inside the `History.md` file](https://github.com/bevry/docpad-plugin-paged/blob/master/History.md#files)

--- a/src/paged.plugin.coffee
+++ b/src/paged.plugin.coffee
@@ -2,11 +2,16 @@
 module.exports = (BasePlugin) ->
 	# Requires
 	{TaskGroup} = require('taskgroup')
+	path = require('path')
 
 	# Define Plugin
 	class PagedPlugin extends BasePlugin
 		# Plugin Name
 		name: 'paged'
+
+		config:
+			cleanurl: false
+			startingPageNumber: 1
 
 		# Extend Collections
 		# Remove our auto pages as our source pages are removed
@@ -180,6 +185,7 @@ module.exports = (BasePlugin) ->
 			docpad = @docpad
 			{collection,templateData} = opts
 			database = docpad.getDatabase()
+			config = @config
 
 			# Create a new collection to temporarily store our pages to render
 			newPagesToRender = []
@@ -221,6 +227,7 @@ module.exports = (BasePlugin) ->
 				numberOfPages = meta.get('pageCount') or 1
 				pageSize = meta.get('pageSize') or 1
 				lastDoc = pageSize * numberOfPages
+				pagePathPrefix = meta.get('pagePathPrefix') or ''
 
 				# if pagedCollection is specified then use that to determine number of pages
 				if meta.get('pagedCollection')
@@ -262,9 +269,21 @@ module.exports = (BasePlugin) ->
 				if numberOfPages > 1
 					[1...numberOfPages].forEach (pageNumber) ->  addTask (complete) ->
 						# Prepare our new page
-						pageFilename = "#{basename}-#{pageNumber}.#{extension}"
-						pageOutFilename = "#{outBasename}.#{pageNumber}.#{outExtension}"
-						pageRelativePath = relativePath.replace(filename, pageFilename)
+						if config.cleanurl
+							pageFilename = "index.#{extension}"
+							pageOutFilename = "index.#{outExtension}"
+							pagePath = path.join((pageNumber + (config.startingPageNumber - 1)).toString(), pageFilename)
+							pagePath = path.join(pagePathPrefix, pagePath) if pagePathPrefix.length > 0
+							if basename is 'index'
+								pageRelativePath = path.join(path.dirname(relativePath), pagePath)
+							else
+								pageRelativePath = path.join(path.dirname(relativePath), basename, pagePath)
+						else
+							pageFilename = "#{basename}-#{pageNumber}.#{extension}"
+							pageOutFilename = "#{outBasename}.#{pageNumber + (config.startingPageNumber - 1)}.#{outExtension}"
+							pagePath = pageFilename
+							pagePath = path.join(pagePathPrefix, pagePath) if pagePathPrefix.length > 0
+							pageRelativePath = path.join(path.dirname(relativePath), pagePath)
 
 						# Log
 						docpad.log('info', "Creating page #{pageNumber} for #{filePath} at #{pageRelativePath}")


### PR DESCRIPTION
This pull request has three enhancements in it that are all intertwined in the same block of 5-10 lines of code dealing with naming of the generated files.  Because of the intertwined nature of the changes, I created a single pull request.  Let me know if you prefer some other approach.  I also attempted to update the README.md with some documentation, but if you don't like the way I documented the new options, let me know.

__Background__

I made all three of these options as part of getting this plugin to generate a file patterns that matched what I was looking for (which was driven mostly by what I had in my old octopress blog).  In particular, my old blog's main index page had /index.html for the first page, /page/2/index.html for the next, /page/3/index.html for the next, etc...

There are three conceptual and reusable changes to make that happen:

__Clean Urls__

I added a cleanurl config option to this plugin to make it generate clean urls straight away.  After some review of this plugin and the cleanurl plugin, this seemed like the cleaner approach (no pun intended).  The alternative of trying to clean up the virtual documents after the fact in the cleanurl plugin seemed more messy.

When cleanurl = true, /archive.html, /archive.1.html, and /archive.2.html become /archive/index.html, /archive/1/index.html, and /archive/2/index.html

There is special case handling for any file named index.html (common for the top level blog index, for example).  In that case, index.html, index.1.html, index.2.html become /index.html, /1/index.html, and /2/index.html

__Starting Page Number__

Normally, the first _extra_ page has a '1' in the name.  In URLs, I found that to be somewhat confusing, because this file is actually the _second_ page.  The startingPageNumber config option allows you to tell the plugin to start at 2 instead of one.  So (with clean urls), you get /archive/, /archive/2/, /archive/3/ instead of /archive/, /archive/1/, /archive/2/.

__Page Path Prefix__

This is a document-specific metadata property.  Particularly in the case of index.html, it may be preferable for the extra pages to not just be /2/, /3/, /4/, but rather to have some name in them.  In my case, I set pagePathPrefix = 'page' and my index.html becomes: /, /page/2/, /page/3/, etc...

__Note:__ In all three cases, the default behavior is consistent with the behavior pre-pull request so these don't affect anything unless people opt-in to them.