### PR TITLE
getPageUrl renamed getPagedUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pageSize: 3
 			<% if @document.page.number is pageNumber: %>
 				<li class="active"><span><%= pageNumber + 1 %></span></li>
 			<% else: %>
-				<li><a href="<%= @getPageUrl(pageNumber) %>"><%= pageNumber + 1 %></a></li>
+				<li><a href="<%= @getPagedUrl(pageNumber) %>"><%= pageNumber + 1 %></a></li>
 			<% end %>
 		<% end %>
 

--- a/src/paged.plugin.coffee
+++ b/src/paged.plugin.coffee
@@ -42,7 +42,7 @@ module.exports = (BasePlugin) ->
 				return subCollection
 
 			# Get the url of the desired page
-			templateData.getPageUrl = (pageNumber, document) ->
+			templateData.getPagedUrl = (pageNumber, document) ->
 				# Prepare
 				document ?= @getDocument()
 				page = document.get('page')
@@ -85,7 +85,7 @@ module.exports = (BasePlugin) ->
 
 				# Check
 				if page.number < page.count-1
-					result = @getPageUrl(page.number+1, document)
+					result = @getPagedUrl(page.number+1, document)
 
 				# Default
 				return result
@@ -111,7 +111,7 @@ module.exports = (BasePlugin) ->
 
 				# Check
 				if page.number > 0
-					result = @getPageUrl(page.number-1, document)
+					result = @getPagedUrl(page.number-1, document)
 
 				# Return
 				return result

--- a/test/src/documents/posts.html.eco
+++ b/test/src/documents/posts.html.eco
@@ -36,7 +36,7 @@ pageSize: 2
 			<% if @document.page.number is pageNumber: %>
 				<li class="active"><span><%= pageNumber + 1 %></span></li>
 			<% else: %>
-				<li><a href="<%= @getPageUrl(pageNumber) %>"><%= pageNumber + 1 %></a></li>
+				<li><a href="<%= @getPagedUrl(pageNumber) %>"><%= pageNumber + 1 %></a></li>
 			<% end %>
 		<% end %>
 

--- a/test/src/documents/posts/awesome.html.eco
+++ b/test/src/documents/posts/awesome.html.eco
@@ -35,7 +35,7 @@ pageSize: 1
 			<% if @document.page.number is pageNumber: %>
 				<li class="active"><span><%= pageNumber + 1 %></span></li>
 			<% else: %>
-				<li><a href="<%= @getPageUrl(pageNumber) %>"><%= pageNumber + 1 %></a></li>
+				<li><a href="<%= @getPagedUrl(pageNumber) %>"><%= pageNumber + 1 %></a></li>
 			<% end %>
 		<% end %>
 

--- a/test/src/documents/split.html.eco
+++ b/test/src/documents/split.html.eco
@@ -34,7 +34,7 @@ pageCount: 3
 			<% if @document.page.number is pageNumber: %>
 				<li class="active"><span><%= pageNumber + 1 %></span></li>
 			<% else: %>
-				<li><a href="<%= @getPageUrl(pageNumber) %>"><%= pageNumber + 1 %></a></li>
+				<li><a href="<%= @getPagedUrl(pageNumber) %>"><%= pageNumber + 1 %></a></li>
 			<% end %>
 		<% end %>
 


### PR DESCRIPTION
The README.md file initially calls one of the helper methods "getPagedUrl".  However it's actually called getPageUrl in the code itself and the code example within the readme file.  "getPagedUrl" would be a safer option for now, to avoid a conflict with "getPageUrl" from docpad-plugin-services.

__Note__: This would break code using this plugin, but they could easily rename the function or we could workaround it by providing an alias?